### PR TITLE
Speed

### DIFF
--- a/R/base-iv.R
+++ b/R/base-iv.R
@@ -19,7 +19,7 @@
 #'
 #' @export
 
-ivregFun <- function(y, x, z, formula) {
+ivregFun <- function(y, x, z, formula, tests) {
 
   # extract formula
   # convert formula to character vector of length 1
@@ -77,7 +77,11 @@ ivregFun <- function(y, x, z, formula) {
     sigma2 <- sum(tmp$residuals^2) / tmp$nobs
     # assume normality of first stage errors for likelihood as Autometrics does
     result$logl <- - (result$n / 2) * (1 + log(2*pi) + log(sigma2))
-    result$diag <- summary(tmp)$diagnostics
+    if (tests == TRUE) {
+      result$diag <- summary(tmp)$diagnostics
+    } else {
+      result$diag <- NULL
+    }
     result$residuals <- residuals(tmp)
     result$std.residuals <- residuals(tmp) / tmp$sigma
 

--- a/R/getsiv.R
+++ b/R/getsiv.R
@@ -40,8 +40,13 @@ ivgets <- function(
   setup <- new_formula(formula = formula, data = data, keep_exog = keep_exog)
 
   # user estimator
+  if (is.null(overid) & is.null(weak)) {
+    test <- FALSE
+  } else {
+    test <- TRUE
+  }
   userest <- list(name = ivgets::ivregFun, z = setup$z,
-                  formula = as.formula(setup$fml))
+                  formula = as.formula(setup$fml), test = test)
 
   # user diagnostics
   is.reject.bad <- NULL

--- a/R/isativ.R
+++ b/R/isativ.R
@@ -39,8 +39,13 @@ ivisat <- function(
   setup <- new_formula(formula = formula, data = data, keep_exog = NULL)
 
   # user estimator
+  if (is.null(overid) & is.null(weak)) {
+    test <- FALSE
+  } else {
+    test <- TRUE
+  }
   userest <- list(name = ivgets::ivregFun, z = setup$z,
-                  formula = as.formula(setup$fml))
+                  formula = as.formula(setup$fml), test = test)
 
   # user diagnostics
   is.reject.bad <- NULL

--- a/README.Rmd
+++ b/README.Rmd
@@ -143,3 +143,4 @@ print(selection$keep)
 ```
 
 The final model has only retained the exogenous theory variables $x_{1}$ and $x_{2}$, which is the correct selection. The data generating process only contained the variables $x_{1}$, $x_{2}$, and $x_{11}$. Their true parameters were `c(6, -5, 3)`, so the estimates are quite close.
+

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ indicators <- isat(base, iis = TRUE, t.pval = 1/100, print.searchinfo = FALSE)
 print(indicators$final)
 #> 
 #> Call:
-#> ivreg::ivreg(formula = as.formula(fml_sel), data = d)
+#> ivreg(formula = as.formula(fml_sel), data = d)
 #> 
 #> Coefficients:
 #>       x1        x2        x3        x4        x5        x6        x7        x8  
@@ -139,7 +139,7 @@ selection <- gets(indicators$final, keep_exog = indicators$selection$ISnames, pr
 print(selection$final)
 #> 
 #> Call:
-#> ivreg::ivreg(formula = as.formula(fml_sel), data = d)
+#> ivreg(formula = as.formula(fml_sel), data = d)
 #> 
 #> Coefficients:
 #>     x1      x2    iis9   iis11   iis43   iis73     x11  

--- a/baseline/profiling.R
+++ b/baseline/profiling.R
@@ -1,0 +1,8 @@
+load("./data/artificial2sls_contaminated.rda")
+fml <- y ~ -1+x1+x2+x3+x4+x5+x6+x7+x8+x9+x10+x11 | -1+x1+x2+x3+x4+x5+x6+x7+x8+x9+x10+z11+z12
+base <- ivreg(formula = fml, data = artificial2sls_contaminated)
+isat(base, iis = TRUE, t.pval = 1/100, print.searchinfo = FALSE)
+
+
+
+profvis(isat(base, iis = TRUE, t.pval = 1/100, print.searchinfo = FALSE))

--- a/man/ivregFun.Rd
+++ b/man/ivregFun.Rd
@@ -4,7 +4,7 @@
 \alias{ivregFun}
 \title{User estimator ivreg for getsFun() and isat()}
 \usage{
-ivregFun(y, x, z, formula)
+ivregFun(y, x, z, formula, tests)
 }
 \arguments{
 \item{y}{A numeric vector with no missing values.}

--- a/tests/testthat/test-base-iv.R
+++ b/tests/testthat/test-base-iv.R
@@ -12,7 +12,7 @@ test_that("ivregFun() works correctly", {
   z <- as.matrix(df[, c("z2"), drop = FALSE])
   fml <- y ~ -1+cons+x1+x2 | -1+cons+x1+z2
 
-  out <- ivregFun(y = y, x = x, z = z, formula = fml)
+  out <- ivregFun(y = y, x = x, z = z, formula = fml, test = TRUE)
 
   # basic tests of type, class, length, names
   expect_type(out, "list")
@@ -43,7 +43,7 @@ test_that("ivregFun() works correctly", {
   expect_snapshot_output(out)
 
   # must be able to handle empty models
-  out <- ivregFun(y = y, x = NULL, z = z, formula = fml)
+  out <- ivregFun(y = y, x = NULL, z = z, formula = fml, test = TRUE)
   expect_type(out, "list")
   expect_length(out, 9)
   expect_named(out, c("n", "k", "df", "coefficients", "vcov", "logl", "diag",
@@ -67,7 +67,7 @@ test_that("ivregFun() works correctly", {
   # must be able to handle models where x deviates from "formula x"
   # e.g. if path search and have deleted some regressors
   x <- x[, -1, drop = FALSE] # suppose cons has been deleted
-  out <- ivregFun(y = y, x = x, z = z, formula = fml)
+  out <- ivregFun(y = y, x = x, z = z, formula = fml, test = TRUE)
   expect_type(out, "list")
   expect_length(out, 9)
   expect_named(out, c("n", "k", "df", "coefficients", "vcov", "logl", "diag",
@@ -97,7 +97,7 @@ test_that("ivregFun() works correctly", {
 
   # now suppose that x1 has been deleted
   x <- as.matrix(df[, c("cons", "x2"), drop = FALSE])
-  out <- ivregFun(y = y, x = x, z = z, formula = fml)
+  out <- ivregFun(y = y, x = x, z = z, formula = fml, test = TRUE)
   expect_type(out, "list")
   expect_length(out, 9)
   expect_named(out, c("n", "k", "df", "coefficients", "vcov", "logl", "diag",
@@ -130,7 +130,7 @@ test_that("ivregFun() works correctly", {
   iis3 <- diag(10)[, 3, drop = FALSE]
   colnames(iis3) <- "iis3"
   x <- cbind(iis3, x)
-  out <- ivregFun(y = y, x = x, z = z, formula = fml)
+  out <- ivregFun(y = y, x = x, z = z, formula = fml, test = TRUE)
 
   expect_type(out, "list")
   expect_length(out, 9)
@@ -162,7 +162,7 @@ test_that("ivregFun() works correctly", {
   # check that position of where iis is added does not matter
   x <- as.matrix(df[, c("cons", "x1", "x2"), drop = FALSE])
   x <- cbind(x[, 1, drop = FALSE], iis3, x[, -1, drop = FALSE]) # is now second
-  out2 <- ivregFun(y = y, x = x, z = z, formula = fml)
+  out2 <- ivregFun(y = y, x = x, z = z, formula = fml, test = TRUE)
 
   expect_type(out2, "list")
   expect_length(out2, 9)
@@ -200,7 +200,7 @@ test_that("ivregFun() works correctly", {
   sis8 <- as.matrix(c(0,0,0,0,0,0,0,1,1,1), nrow = 10, ncol = 1)
   colnames(sis8) <- "sis8"
   x <- cbind(iis3, sis8, x)
-  out <- ivregFun(y = y, x = x, z = z, formula = fml)
+  out <- ivregFun(y = y, x = x, z = z, formula = fml, test = TRUE)
 
   expect_type(out, "list")
   expect_length(out, 9)
@@ -246,7 +246,7 @@ test_that("ivDiag() works correctly", {
   x <- as.matrix(df[, c("cons", "x1", "x2"), drop = FALSE])
   z <- as.matrix(df[, c("z2", "z3"), drop = FALSE])
   fml <- y ~ -1+cons+x1+x2 | -1+cons+x1+z2+z3
-  out <- ivregFun(y = y, x = x, z = z, formula = fml)
+  out <- ivregFun(y = y, x = x, z = z, formula = fml, test = TRUE)
 
   # no misspecification test specified
   expect_identical(ivDiag(x = out, weak = FALSE, overid = FALSE), NULL)
@@ -290,7 +290,7 @@ test_that("ivDiag() works correctly", {
   df$x3 <- stats::rnorm(10) # endogenous regressor
   x <- as.matrix(df[, c("cons", "x1", "x2", "x3"), drop = FALSE])
   fml <- y ~ -1+cons+x1+x2+x3 | -1+cons+x1+z2+z3
-  out <- ivregFun(y = y, x = x, z = z, formula = fml)
+  out <- ivregFun(y = y, x = x, z = z, formula = fml, test = TRUE)
   d <- ivDiag(x = out, weak = TRUE, overid = FALSE) # now have two tests weak
   expect_identical(class(d), c("matrix", "array"))
   expect_identical(dim(d), c(2L, 3L))


### PR DESCRIPTION
- Profiling code to detect bottlenecks
- creating diagnostics from ivreg::summary() command takes long, so turned off now when no diagnostics required
- if no diagnostics, now only takes approx. 50% of the time
- further savings possible in how diagnostics are handled but negligible (profiling showed out of 12 seconds, 10 are directly in getsFun, so cannot speed it up there directly)
- might be able to speed up if implement 2SLS estimator directly and don't rely on ivreg package